### PR TITLE
Modify header and sidebar - pt 2

### DIFF
--- a/js/client/src/components/app/App.js
+++ b/js/client/src/components/app/App.js
@@ -3,7 +3,6 @@ import MainMap from "./map/Map";
 import Geosearch from "./Geosearch";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
-import Instructions from "./Instructions";
 
 import "../../sass/main.scss";
 
@@ -11,7 +10,6 @@ function App() {
   return (
     <div className="App">
       <Header />
-      <Instructions />
       <Sidebar />
       <Geosearch />
       <MainMap />

--- a/js/client/src/components/app/Header.js
+++ b/js/client/src/components/app/Header.js
@@ -1,16 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
+import Instructions from "./Instructions";
+import logo from "../../assets/images/logo.png";
 
 function Header() {
+  const [showInstructions, setShowInstructions] = useState(true);
+
+  const handleShow = (e) => {
+    setShowInstructions(!showInstructions);
+  };
+
+  const headerClass = showInstructions === true ? "header-container-show-instr" : "header-container";
+
   return (
-    <div className="header-container">
-      <div className="picture" />
-      <div>
-        <h1>LOS ANGELES PARKING CITATION DATA</h1>
-        <p>
-          Helping L.A. communities make informed decisions about parking
-          policies
-        </p>
-      </div>
+    <div className={headerClass}>
+      <img src={logo} alt="Logo" className="picture" />
+      <div className="line" id="line1" />
+      <h4>LOS ANGELES PARKING CITATION DATA</h4>
+      <div className="line" id="line2" />
+      <p>
+        Helping L.A. communities make informed decisions about parking
+        policies
+      </p>
+      <Instructions show={showInstructions} handleShow={handleShow} />
     </div>
   );
 }

--- a/js/client/src/components/app/Instructions.js
+++ b/js/client/src/components/app/Instructions.js
@@ -1,27 +1,28 @@
 import React, { useState } from "react";
 import polygonToolIconButton from "../../assets/images/polygon.png";
-function Instructions() {
-  const [show, setShow] = useState(true);
 
-  const handleShow = (e) => {
-    setShow(!show);
-  };
+function Instructions({ show, handleShow }) {
+  // const [show, setShow] = useState(true);
+
+  // const handleShow = (e) => {
+  //   setShow(!show);
+  // };
 
   return show ? (
     <div className="instructions-container">
-      <h3>HOW IT WORKS:</h3>
+      <h2>HOW IT WORKS:</h2>
       <div className="instructions">
-        <p>
+        <p className="text-description">
           Navigate by searching any location within Los Angeles County in the
           Search Bar. Pan by dragging the mouse. Zoom by scrolling up and down
           or using the buttons in the bottom right.
         </p>
         <br />
-        <p>
+        <p className="text-description">
           View parking citation data using any of the following:
           <ul>
             <li>
-              <small>
+              <small className="bullet-point">
                 To select by zip code, click the &nbsp;
                 <img
                   src="https://img.icons8.com/material-outlined/24/000000/zip-code.png"
@@ -33,7 +34,7 @@ function Instructions() {
               </small>
             </li>
             <li>
-              <small>
+              <small className="bullet-point">
                 To select a custom region, click the &nbsp;
                 <img src={polygonToolIconButton} alt="polygon tool icon" />
                 &nbsp; button to use a polygon selection tool. Click and then
@@ -48,7 +49,7 @@ function Instructions() {
     </div>
   ) : (
     <div className="button-container">
-      <button className="button-instructions" onClick={handleShow}>Click for Instructions</button>
+      <button className="button-instructions" onClick={handleShow}>Instructions</button>
     </div>
   );
 }

--- a/js/client/src/components/app/Sidebar.js
+++ b/js/client/src/components/app/Sidebar.js
@@ -103,7 +103,7 @@ function ConnectedSideBar({
           {/* If abbreviation is not in the table, use 'Other' */}
           <div className="leftData">{tables.typeTable[data.body_style] || "Other"}</div>
         </div>
-        <div className="bottomLeft">
+        <div className="left">
           Color
           {/* If abbreviation is not in the table, use 'Other' */}
           <div className="leftData">{tables.colorTable[data.color] || "Other"}</div>

--- a/js/client/src/components/app/map/Map.js
+++ b/js/client/src/components/app/map/Map.js
@@ -156,7 +156,7 @@ const ConnectedMap = ({
         accessToken: mapboxgl.accessToken,
         mapboxgl: mapboxgl,
         bbox: [bounds[0][0], bounds[0][1], bounds[1][0], bounds[1][1]],
-        placeholder: "Search within the Los Angeles County",
+        placeholder: "Search location",
       });
       mapRef.current.appendChild(geocoder.onAdd(map));
     });

--- a/js/client/src/sass/components/_geosearch.scss
+++ b/js/client/src/sass/components/_geosearch.scss
@@ -51,15 +51,30 @@ $desktop: 900px;
     grid-row: 2/3;
     display: flex;
     margin: 0 20px;
+    // Disable searching on smaller screens until we fix responsiveness
+    display: none;
   }
   @media screen and (min-width: $desktop) {
-    grid-column: 2/4;
+    position: absolute;
+    z-index: 1;
     display: flex;
-    justify-content: center;
-    margin: 0 20px;
+
+    // To center geosearch bar on the screen
+    margin: 1em 10vw 0 10vw;
+    max-width: 80vw;
+    width: 100%;
+    // End centering
+
+    background-color: #FFFFFF;
+    opacity: 0.75;
+    border-radius: 50px;
   }
   @media (prefers-color-scheme: dark) {
     @include dark-mode;
+  }
+
+  &:hover {
+    opacity: 1;
   }
 }
 
@@ -67,7 +82,6 @@ $desktop: 900px;
   display: flex;
   align-items: center;
   font-size: 1em;
-  color: grey;
   &--active {
     border: 1px solid lightgray;
     animation: outwardPulse 2s infinite;
@@ -131,7 +145,7 @@ $desktop: 900px;
   &--visible {
     display: block;
     font-weight: bold;
-    font-size: 1.5rem;
+    font-size: 1em;
     color: #47be22;
     transition: color 1s;
     &:hover {

--- a/js/client/src/sass/components/_header.scss
+++ b/js/client/src/sass/components/_header.scss
@@ -1,34 +1,111 @@
+@mixin header {
+  width: 100vw;
+  background-color: white;
+  color: black;
+}
+
+/** 
+ * Header when instructions window is collapsed
+ */
 .header-container {
   @media #{$bp-desktop-up} {
+    @include header;
     display: flex;
     flex-direction: row;
-    align-items: stretch;
-    align-content: center;
-    height: auto;
-    width: 100vw;
-    padding: 1em 1.5em;
-    background-color: white;
-    color: black;
-    font-size: 1.5em;
-    line-height: 1.5em;
-    letter-spacing: 0.055em;
-
-    h1 {
-      font-size: #{map-get($font-size-h1, desktop)};
-      font-weight: #{map-get($font-weight, normal)};
-      line-height: #{map-get($line-height-h1, desktop)};;
-      letter-spacing: 0;
-    }
+    justify-content: space-around;
+    align-items: center;
+    height: 5vh;
 
     .picture {
       @media (prefers-color-scheme: dark) {
         border-radius: 50px;
       }
+      max-height: 29px;
+      max-width: 199px;
+    }
+    
+    h4 {
+      font-size: #{map-get($font-size-h4, desktop)};
+      font-weight: #{map-get($font-weight, medium)};
+      line-height: #{map-get($line-height-h4, desktop)};
+      letter-spacing: 0.0105em;
+      text-align: center;
+    }
 
-      flex: 0.65 0 auto;
-      min-width: 230px;
-      background-image: url("../../assets/images/logo.png");
-      background-repeat: no-repeat;
+    p {
+      font-size: #{map-get($font-size-h4, desktop)};
+      font-weight: #{map-get($font-weight, light)};
+      line-height: #{map-get($line-height-h4, desktop)};
+      letter-spacing: 0.02em;
+      text-align: center;
+    }
+
+    .line {
+      border-left: 0.5px solid black;
+      height: 1em;
+      margin-left: 1em;
+      margin-right: 1em;
+      justify-self: center;
+    }
+  }
+}
+
+/** 
+ * Header when instructions window is expanded
+ */
+.header-container-show-instr {
+  @media #{$bp-desktop-up} {
+    @include header;
+    display: grid;
+    align-items: center;
+    grid-template-columns: 25vw 5vw 25vw 5vw 40vw;
+    grid-template-rows: 5vh auto;
+    grid-template-areas: 
+     "picture line1 header line2 desc"
+     "instr instr instr instr instr";
+
+    .picture {
+      @media (prefers-color-scheme: dark) {
+        border-radius: 50px;
+      }
+      grid-area: picture;
+      max-height: 29px;
+      max-width: 199px;
+      justify-self: center;
+    }
+    
+    h4 {
+      grid-area: header;
+      font-size: #{map-get($font-size-h4, desktop)};
+      font-weight: #{map-get($font-weight, medium)};
+      line-height: #{map-get($line-height-h4, desktop)};
+      letter-spacing: 0.0105em;
+      text-align: center;
+    }
+
+    p {
+      grid-area: desc;
+      font-size: #{map-get($font-size-h4, desktop)};
+      font-weight: #{map-get($font-weight, light)};
+      line-height: #{map-get($line-height-h4, desktop)};
+      letter-spacing: 0.02em;
+      text-align: center;
+    }
+
+    .line {
+      border-left: 0.5px solid black;
+      height: 1em;
+      margin-left: 1em;
+      margin-right: 1em;
+      justify-self: center;
+    }
+
+    #line1 {
+      grid-area: line1;
+    }
+
+    #line2 {
+      grid-area: line2;
     }
   }
 }

--- a/js/client/src/sass/components/_instructions.scss
+++ b/js/client/src/sass/components/_instructions.scss
@@ -1,59 +1,73 @@
+/** 
+ * When instructions window is expanded
+ */
 .instructions-container {
+  grid-area: instr;
   display: flex;
-  align-items: stretch;
+  justify-content: center;
   height: auto;
   width: 100vw;
   background-color: #e5e5e5;
   color: black;
-  font-size: 1.5em;
+  padding: 3em 0 1em 0;
 
-  h3 {
-    margin: 2em 2em 0 3em;
-    font-size: #{map-get($font-size-h3, desktop)};
+  h2 {
+    margin-right: 2em;
+    font-size: 30px;
     font-weight: #{map-get($font-weight, bold)};
     white-space: nowrap;
-    letter-spacing: 0;
+  }
+
+  .instructions {
+    display: flex;
+    flex-direction: column;
+    width: 50%;
+    align-self: center;
+    
+    .text-description {
+      font-weight: #{map-get($font-weight, normal)};
+      line-height: #{map-get($line-height-base, desktop)};
+      font-size: 18px;
+      text-align: left;
+
+      .bullet-point {
+        font-weight: #{map-get($font-weight, light)};
+        line-height: #{map-get($line-height-base, desktop)};
+      }
+    }
+
+    ul {
+      margin: 0.5em 1em 0 1em;
+    }
+  
+    .button-instructions {
+      width: 130px;
+      height: 32px;
+      margin: 2em 0 0 10em;
+      font-weight: #{map-get($font-weight, bold)};
+      font-size: 14px;
+      color: white;
+      background-color: #858585;
+      border-radius: 2px;
+    }
   }
 }
 
-.instructions {
-  display: flex;
-  flex-direction: column;
-  align-content: center;
-  align-items: center;
-  margin: 0.5em 0em;
-  padding: 1em 3em 0 0;
-
-  ul {
-    margin: 0.5em 1em 0 1em;
-  }
-
-  .button-instructions {
-    font-weight: #{map-get($font-weight, semibold)};
-    line-height: 2.3em;
-    font-size: 0.7em;
-    letter-spacing: 0.05em;
-    min-width: 21em;
-    color: white;
-    background-color: black;
-    margin-right: 16em;
-  }
-}
-
+/** 
+ * When instructions window is collapsed
+ */
 .button-container {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: white;
-  margin-bottom: 0.5em;
 
   .button-instructions {
-    font-weight: #{map-get($font-weight, semibold)};
-    line-height: 2.3em;
-    font-size: 1em;
-    letter-spacing: 0.05em;
-    min-width: 22em;
+    width: 109px;
+    height: 29px;
+    font-weight: #{map-get($font-weight, bold)};
+    font-size: 14px;
     color: white;
-    background-color: black;
+    background-color: #858585;
+    border-radius: 2px;
   }
 }

--- a/js/client/src/sass/components/_sidebar.scss
+++ b/js/client/src/sass/components/_sidebar.scss
@@ -67,7 +67,6 @@ $desktop: 900px;
     transform: translateX(-30rem);
     position: absolute;
     padding: 0 2em 1em 2em;
-    margin-top: -1.5em;
   }
 
   border: 1px lightgray solid;
@@ -120,12 +119,130 @@ $desktop: 900px;
   }
 }
 
+/**
+ * Sidebar contents
+ */
 .content-wrapper {
+  height: 100%;
+
+  .header-text {
+    font-size: #{map-get($font-size-title3, desktop)};
+    font-family: Helvetica, sans-serif;
+    font-weight: #{map-get($font-weight, bold)};
+    text-align: center;
+    padding: 1em 0;
+  }
+  
+  .title {
+    text-decoration: underline;
+    font-size: #{map-get($font-size-title4, desktop)};
+    font-family: Helvetica, sans-serif;
+    color: #47be22;
+    margin-bottom: 0.2em;
+  }
+  
+  .desc {
+    font-family: DIN1451Alt;
+    font-size: 0.8em;
+    margin-left: 1em;
+    margin-bottom: 0.2em;
+  }
+  
+  .vehicle {
+    font-family: VT323;
+    text-decoration: underline;
+    font-size: #{map-get($font-size-title2, desktop)};
+    margin: 0.5em 1.5em 0.25em 1.5em;
+  }
+  
+  .left {
+    border: solid black 1px;
+    font-family: Helvetica, sans-serif;
+    font-size: 0.7em;
+    // Ensures double overlapping borders do not appear
+    margin-bottom: -1px;
+    line-height: 1;
+  }
+  
+  .leftData {
+    font-family: VT323;
+    margin-left: 0.5em;
+    font-size: 2em;
+  }
+  
+  .fine {
+    font-family: VT323;
+    text-decoration: underline;
+    font-size: #{map-get($font-size-title2, desktop)};
+    margin: 0.5em 0.75em 0.25em 0.75em;
+  }
+  
+  .dollar {
+    font-family: VT323;
+    font-size: 3em;
+    color: #008000;
+    margin: 0 0 0 1em;
+  }
+  
+  .dollarAmt {
+    font-family: DIN1451Alt;
+    font-size: 0.8em;
+    color: black;
+  }
+
   @media screen and (max-width: $phone) {
     overflow: scroll !important;
     max-height: 53%;
   }
   @media screen and (min-width: $desktop) {
+    display: flex;
+    flex-direction: column;
+  }
+  /**
+   * Special case: When the app is rendered on a laptop with shorter viewport height,
+   * make the sidebar font sizes and spacing smaller
+   */
+  @media screen and (max-height: 800px) and (min-width: $desktop) {
+    .header-text {
+      font-size: #{map-get($font-size-title4, desktop)};
+      font-weight: #{map-get($font-weight, bold)};
+      text-align: center;
+      padding: 0.5em 0;
+    }
+
+    .title {
+      font-size: #{map-get($font-size-title5, desktop)};
+    }
+    
+    .desc {
+      font-size: 0.8em;
+      margin-left: 1em;
+    }
+    
+    .vehicle {
+      font-size: #{map-get($font-size-title3, desktop)};
+      margin: 0.2em 1.5em 0em 1.5em;
+    }
+    
+    .left {
+      border: solid black 1px;
+      font-family: Helvetica, sans-serif;
+      font-size: 0.7em;
+      // Ensures double overlapping borders do not appear
+      margin-bottom: -1px;
+      line-height: 1;
+    }
+    
+    .leftData {
+      font-family: VT323;
+      margin-left: 0.5em;
+      font-size: 2em;
+    }
+    
+    .fine {
+      font-size: #{map-get($font-size-title3, desktop)};
+      margin: 0.2em 0.75em 0em 0.75em;
+    }
   }
 }
 
@@ -163,77 +280,6 @@ $desktop: 900px;
   display: none;
 }
 
-.header-text {
-  font-size: #{map-get($font-size-title3, desktop)};
-  font-family: Helvetica, sans-serif;
-  font-weight: bold;
-  text-align: center;
-  padding-top: 1em;
-  padding-bottom: 1em;
-}
-
-.title {
-  text-decoration: underline;
-  font-size: #{map-get($font-size-title4, desktop)};
-  font-family: Helvetica, sans-serif;
-  color: #47be22;
-  margin-bottom: 0.2em;
-}
-
-.desc {
-  font-family: DIN1451Alt;
-  font-size: 0.8em;
-  margin-left: 1em;
-  margin-bottom: 0.2em;
-}
-
-.vehicle {
-  font-family: VT323;
-  text-decoration: underline;
-  font-size: #{map-get($font-size-title2, desktop)};
-  margin: 0.5em 1.5em 0.25em 1.5em;
-}
-
-.left {
-  border: solid black 1px;
-  font-family: Helvetica, sans-serif;
-  font-size: 0.7em;
-  border-bottom: none;
-  line-height: 1;
-}
-
-.bottomLeft {
-  border: solid black 1px;
-  font-family: Helvetica, sans-serif;
-  font-size: 0.7em;
-}
-
-.leftData {
-  font-family: VT323;
-  margin-left: 0.5em;
-  font-size: 2em;
-  // line-height: 1;
-}
-
-.fine {
-  font-family: VT323;
-  text-decoration: underline;
-  font-size: #{map-get($font-size-title2, desktop)};
-  margin: 0.5em 0.75em 0.25em 0.75em;
-}
-
-.dollar {
-  font-family: VT323;
-  font-size: 4em;
-  color: #008000;
-  margin: 0 0 0 1em;
-}
-
-.dollarAmt {
-  font-family: DIN1451Alt;
-  font-size: 0.8em;
-  color: black;
-}
 
 .sidebar__closeButton--close {
   height: 15px;

--- a/js/client/src/sass/main.scss
+++ b/js/client/src/sass/main.scss
@@ -40,9 +40,9 @@ body {
     left: 50%;
     top: 45%;
     transform: translate(-50%, -50%);
-    margin: 2em 0;
+    margin: 3em 0 0 0;
     // font-family: "Roboto", sans-serif;
-    font-weight: 300;
+    // font-weight: 300;
   }
   @media (prefers-color-scheme: dark) {
     @include dark-mode;

--- a/js/client/src/sass/variables/_typography.scss
+++ b/js/client/src/sass/variables/_typography.scss
@@ -12,6 +12,7 @@ $font-family: (
 $font-weight: (
   light: 300,
   normal: 400,
+  medium: 500,
   semibold: 600,
   bold: 700
 );


### PR DESCRIPTION
Fixes #310 

### Actions
- Changed how the header looks:
    - When instructions are expanded, the header is a two-row grid
    - When instructions are collapsed, the header is a single row flex container
    - To do the above, moved "Instructions" component to be part of "Header" component
- Moved the Search to be display on top of the map, with some opacity
    - On hover, opacity becomes 1
    - CSS of this component is currently structured poorly, so would need some refactoring in the future
    - Responsiveness of this component needs to be fixed because below the desktop viewport, it doesn't work perfectly. As such, I set this component to "disappear" below a desktop screen
- Modified citations sidebar so that when the height of the viewport is less than 800px (while still on desktop viewport), the contents are smaller
    - This ensures that the ticket does not get cut off

### Future work
- A lot of scss files are not structured and need work
- Responsiveness below desktop viewport needs a lot of work for all the components

### Screenshots
<details>
<summary>Main page with instructions</summary>

![full-instr](https://user-images.githubusercontent.com/48004150/139183210-cf664bc2-d0fa-4b7a-bf10-447ab3e82ba8.png)

</details>

<details>
<summary>Main page with no instructions</summary>

![full-no-instr](https://user-images.githubusercontent.com/48004150/139183222-8a3cdff3-0338-4037-9cae-811c474f3cb9.png)

</details>

<details>
<summary>Citations</summary>

![sidebar](https://user-images.githubusercontent.com/48004150/139183238-dab98aa9-f021-4179-8422-69e1988e775b.png)

</details>

<details>
<summary>Citations on smaller viewport height</summary>

![sidebar-shorter-height](https://user-images.githubusercontent.com/48004150/139183248-99edea66-b15b-4644-8107-076b7af2a4bb.png)

</details>

<details>
<summary>Polygon tool</summary>

![polygon](https://user-images.githubusercontent.com/48004150/139183478-8676d1cb-d042-4b56-9308-6452cff7eab6.png)

</details>

<details>
<summary>Zip</summary>

![zip](https://user-images.githubusercontent.com/48004150/139183492-afc70ca4-20ec-43ed-a018-e8427967aa7a.png)

</details>