### PR TITLE
Update async error handling for express

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -6,7 +6,7 @@ const compression = require('compression');
 const router = require('./routes/router');
 
 const httpRequestsLogger = require('./middleware/httpRequests.middleware');
-const errorHandler = require('./middleware/errors.middleware');
+const errors = require('./middleware/errors.middleware');
 const logger = require('./utils/logger');
 
 app.use(cors({
@@ -20,7 +20,7 @@ app.use(httpRequestsLogger.requestInfo);
 
 app.use('/api', router);
 
-app.use(errorHandler.unknownEndpoint);
-app.use(errorHandler.errorHandler);
+app.use(errors.unknownEndpoint);
+app.use(errors.errorHandler);
 
 module.exports = app;

--- a/server/middleware/errors.middleware.js
+++ b/server/middleware/errors.middleware.js
@@ -1,16 +1,22 @@
 const logger = require('../utils/logger');
 
 // middleware for unknown endpoints
-const unknownEndpoint = (request, response) => {
-  response.status(404).send({ error: 'unknown endpoint' });
+const unknownEndpoint = (req, res) => {
+  res.status(404).json({
+    error: 'Unknown endpoint',
+    success: false,
+  });
 }
 
 // middleware for handling errors
-const errorHandler = (error, request, response, next) => {
-  logger.error(error.message);
-  response.status(404).send(error);
+const errorHandler = (err, req, res, next) => {
+  // logger.error(err.message);
+  res.status(400).json({
+    error: err.message,
+    success: false,
+  });
   
-  next(error);
+  next(err);
 }
 
 module.exports = {


### PR DESCRIPTION
Updates async error handling. Currently, the stable version of express needs to use the package "express-async-errors" to properly throw errors without the need to use try/catch blocks and using "next". 

When ver 5 of express becomes stable and available, we can remove this package and modify the backend error handling.

Changes:
 - Removing try/catch blocks in controllers.js because express-async-errors package will handle them
 - Update some variable names to be more consistent