### PR TITLE
Fix camera movement

### DIFF
--- a/client/src/components/app/map/Map.js
+++ b/client/src/components/app/map/Map.js
@@ -229,7 +229,6 @@ const ConnectedMap = ({
     */
     const drawnData = async () => {
       var drawData = draw.getAll();
-
       try {
         const response = await axios.get(`${API_URL}/api/citation/draw`, {
           params: {
@@ -246,7 +245,7 @@ const ConnectedMap = ({
         );
         drawPolygon[0].disabled = true;
         drawPolygon[0].classList.add("disabled-button");
-
+        
         cameraMovement(drawData.features[0].geometry.coordinates);
       } catch (err) {
         console.log(err);
@@ -364,9 +363,10 @@ const ConnectedMap = ({
       const zip = e.features[0].properties.zipcode;
       const zipSource = map.getSource("zipcodes");
       const zipGeometry = {};
+
       // From all the possible zipcodes, get the specific zip only
       for (let element of zipSource["_data"].features){
-        if (element.id === zip){
+        if (element.properties.zipcode === zip){
           zipGeometry.data = element;
           break;
         }

--- a/server/controllers/controllers.js
+++ b/server/controllers/controllers.js
@@ -114,9 +114,9 @@ const drawSelect = async (req, res) => {
   const polygon = req.query.polygon;
   const data = await db.query(
     `SELECT ST_AsGeoJSON(geometry) FROM test1 WHERE ST_Contains(ST_GeomFromGeoJSON('{
-      'type': 'Polygon',
-      'coordinates': [${polygon}],
-      'crs': {'type': 'name', 'properties': {'name': 'EPSG:4326'}}										                            
+      "type": "Polygon",
+      "coordinates": [${polygon[0]}],
+      "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}										                            
     }'), test1.geometry) LIMIT 30000;`
   );
 


### PR DESCRIPTION
Camera motion broke on the dev branch.
Fixes SQL query for draw select and fixes the zipcode selection on front end for zip select.
Draw select still has some weird bug where after the first drawn polygon, it pans out and citations outside the region also show.