### PR TITLE
Revert to PM2 for production deployment

### DIFF
--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -2,9 +2,13 @@
 cd ~/lucky-parking/server
 # Pull code from repo
 sudo git pull
-# Stop docker
-sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml down -v
-# Restart database
+pm2 stop "npm run server:dev"
+# kill the node process
+sudo pkill -f 'nodemon'
+sudo pkill -f 'node'
+# restart sql
 sudo systemctl restart postgresql
-# Run docker in production mode
-sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+# install packages silently
+npm install &>/dev/null
+# start the server then exit the cmd shell
+pm2 start "npm run server:dev" 


### PR DESCRIPTION
Since docker is creating unnecessary space and slowness for the website, we're reverting back to just using PM2 for site deployment. (Local dev will still use docker)