### PR TITLE
Testing Coverage for Citation Data Filter

### DIFF
--- a/packages/ui/src/components/date-input/date-input.test.tsx
+++ b/packages/ui/src/components/date-input/date-input.test.tsx
@@ -8,7 +8,7 @@ describe("Date Input", () => {
   beforeEach(async () => {
     render(
       <div>
-        <DateInput>From</DateInput>
+        <DateInput id="From">From</DateInput>
         <button data-testid="outside-event-listener">Exit calendar</button>
       </div>,
     );

--- a/packages/ui/src/components/date-input/date-input.tsx
+++ b/packages/ui/src/components/date-input/date-input.tsx
@@ -3,7 +3,12 @@ import { PropsWithChildren, useEffect, useRef, useState } from "react";
 import Calendar from "../calendar";
 import { formatToMiddleEndian } from "./utils/date";
 
-export default function DateInput({ children }: PropsWithChildren) {
+interface DateInputProps {
+  id: string;
+  children: PropsWithChildren;
+}
+
+export default function DateInput({ id, children }: PropsWithChildren<DateInputProps>) {
   const calendarRef = useRef<HTMLDivElement>(null);
   const [value, setValue] = useState<string | null>();
   const [isCalendarVisible, setCalendarVisible] = useState(false);
@@ -25,6 +30,7 @@ export default function DateInput({ children }: PropsWithChildren) {
     <div className="relative flex-auto">
       <div
         data-testid="date-input-trigger"
+        aria-label={id}
         className={clsx(
           "flex h-[48px] flex-auto flex-col items-start justify-center ",
           "px-4 text-base leading-[22.4px]",

--- a/packages/ui/src/components/date-input/date-input.tsx
+++ b/packages/ui/src/components/date-input/date-input.tsx
@@ -8,7 +8,8 @@ interface DateInputProps {
   children: PropsWithChildren;
 }
 
-export default function DateInput({ id, children }: PropsWithChildren<DateInputProps>) {
+export default function DateInput({ children, ...props }: PropsWithChildren<DateInputProps>) {
+  const { id } = props;
   const calendarRef = useRef<HTMLDivElement>(null);
   const [value, setValue] = useState<string | null>();
   const [isCalendarVisible, setCalendarVisible] = useState(false);

--- a/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
+++ b/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
@@ -18,17 +18,8 @@ describe("Citation-data-filter rendering", () => {
   });
 
   test("should render date inputs with initial placeholders", async () => {
-    const fromInput = screen.getByText("From");
-    const toInput = screen.getByText("To");
-
-    expect(fromInput).toBeInTheDocument();
-    expect(toInput).toBeInTheDocument();
-
-    const fromValue = fromInput.nextElementSibling;
-    const toValue = toInput.nextElementSibling;
-
-    expect(fromValue).toHaveTextContent("mm/dd/yy");
-    expect(toValue).toHaveTextContent("mm/dd/yy");
+    expect(screen.getByLabelText("From")).toHaveTextContent("mm/dd/yy");
+    expect(screen.getByLabelText("To")).toHaveTextContent("mm/dd/yy");
   });
 });
 
@@ -44,16 +35,33 @@ describe("Citation-data-filter interactions", () => {
 
     await user.click(screen.getByRole("combobox", { name: "citation-date-presets" }));
     await user.click(screen.getByRole("option", { name: "Year to Date" }));
+
+    await user.click(screen.getByLabelText("From"));
+    await user.click(screen.getByRole("combobox", { name: "Month" }));
+    await user.click(screen.getByRole("option", { name: "January" }));
+    await user.click(screen.getByRole("combobox", { name: "Year" }));
+    await user.click(screen.getByRole("option", { name: "2020" }));
+    await user.click(screen.getByText("25"));
+
+    await user.click(screen.getByLabelText("To"));
+    await user.click(screen.getByRole("combobox", { name: "Month" }));
+    await user.click(screen.getByRole("option", { name: "February" }));
+    await user.click(screen.getByRole("combobox", { name: "Year" }));
+    await user.click(screen.getByRole("option", { name: "2023" }));
+    await user.click(screen.getByText("27"));
   });
 
   test("should not render with default options", () => {
     expect(screen.queryByText("Total # Citations")).toBe(null);
     expect(screen.queryByText("Past 1 Year")).toBe(null);
+    expect(screen.queryByText("mm/dd/yy")).toBe(null);
   });
 
   test("should render with selected options", async () => {
     expect(screen.getByText("Violation Type"));
     expect(screen.getByText("Year to Date"));
+    expect(screen.getByText("01/25/2020"));
+    expect(screen.getByText("02/27/2023"));
   });
 
   test("should return selected options", async () => {

--- a/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
+++ b/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
@@ -16,6 +16,7 @@ describe("Citation-data-filter rendering", () => {
   test("should render citation date presets with initial placeholder", async () => {
     expect(screen.getByText("Past 1 Year"));
   });
+
   test("should render date inputs with initial placeholders", async () => {
     const fromInput = screen.getByText("From");
     const toInput = screen.getByText("To");
@@ -28,5 +29,35 @@ describe("Citation-data-filter rendering", () => {
 
     expect(fromValue).toHaveTextContent("mm/dd/yy");
     expect(toValue).toHaveTextContent("mm/dd/yy");
+  });
+});
+
+describe("Citation-data-filter interactions", () => {
+  const onCategorySelectMock = jest.fn();
+  const onDatePresetSelectMock = jest.fn();
+  beforeEach(async () => {
+    const user = userEvent.setup();
+    render(<CitationDataFilter onCategorySelect={onCategorySelectMock} onDatePresetSelect={onDatePresetSelectMock} />);
+
+    await user.click(screen.getByRole("combobox", { name: "citation-data-categories" }));
+    await user.click(screen.getByRole("option", { name: "Violation Type" }));
+
+    await user.click(screen.getByRole("combobox", { name: "citation-date-presets" }));
+    await user.click(screen.getByRole("option", { name: "Year to Date" }));
+  });
+
+  test("should not render with default options", () => {
+    expect(screen.queryByText("Total # Citations")).toBe(null);
+    expect(screen.queryByText("Past 1 Year")).toBe(null);
+  });
+
+  test("should render with selected options", async () => {
+    expect(screen.getByText("Violation Type"));
+    expect(screen.getByText("Year to Date"));
+  });
+
+  test("should return selected options", async () => {
+    expect(onCategorySelectMock).toHaveBeenCalledWith("Violation Type");
+    expect(onDatePresetSelectMock).toHaveBeenCalledWith("Year to Date");
   });
 });

--- a/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
+++ b/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import CitationDataFilter from "./citation-data-filter";
+
+describe("Citation-data-filter rendering", () => {
+  beforeEach(() => {
+    render(<CitationDataFilter onCategorySelect={() => {}} onDatePresetSelect={() => {}} />);
+  });
+
+  test("should redner citation data categories with initial placeholder", async () => {
+    expect(screen.getByText("Total # Citations"));
+  });
+
+  test("should render citation date presets with initial placeholder", async () => {
+    expect(screen.getByText("Past 1 Year"));
+  });
+  test("should render date inputs with initial placeholders", async () => {
+    const fromInput = screen.getByText("From");
+    const toInput = screen.getByText("To");
+
+    expect(fromInput).toBeInTheDocument();
+    expect(toInput).toBeInTheDocument();
+
+    const fromValue = fromInput.nextElementSibling;
+    const toValue = toInput.nextElementSibling;
+
+    expect(fromValue).toHaveTextContent("mm/dd/yy");
+    expect(toValue).toHaveTextContent("mm/dd/yy");
+  });
+});

--- a/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
+++ b/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import CitationDataFilter from "./citation-data-filter";

--- a/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
+++ b/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
@@ -9,7 +9,7 @@ describe("Citation-data-filter rendering", () => {
     render(<CitationDataFilter onCategorySelect={() => {}} onDatePresetSelect={() => {}} />);
   });
 
-  test("should redner citation data categories with initial placeholder", async () => {
+  test("should render citation data categories with initial placeholder", async () => {
     expect(screen.getByText("Total # Citations"));
   });
 

--- a/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
+++ b/packages/website/src/features/citation/ui/citation-data-filter.test.tsx
@@ -4,68 +4,73 @@ import userEvent from "@testing-library/user-event";
 
 import CitationDataFilter from "./citation-data-filter";
 
-describe("Citation-data-filter rendering", () => {
-  beforeEach(() => {
-    render(<CitationDataFilter onCategorySelect={() => {}} onDatePresetSelect={() => {}} />);
+describe("Citation-data-filter", () => {
+  describe("rendering", () => {
+    beforeEach(() => {
+      render(<CitationDataFilter onCategorySelect={() => {}} onDatePresetSelect={() => {}} />);
+    });
+
+    it("renders citation data categories with initial placeholder", async () => {
+      expect(screen.getByText("Total # Citations"));
+    });
+
+    it("renders citation date presets with initial placeholder", async () => {
+      expect(screen.getByText("Past 1 Year"));
+    });
+
+    it("renders date inputs with initial placeholders", async () => {
+      expect(screen.getByLabelText("From")).toHaveTextContent("mm/dd/yy");
+      expect(screen.getByLabelText("To")).toHaveTextContent("mm/dd/yy");
+    });
   });
 
-  test("should render citation data categories with initial placeholder", async () => {
-    expect(screen.getByText("Total # Citations"));
-  });
+  describe("interactions", () => {
+    const onCategorySelectMock = jest.fn();
+    const onDatePresetSelectMock = jest.fn();
 
-  test("should render citation date presets with initial placeholder", async () => {
-    expect(screen.getByText("Past 1 Year"));
-  });
+    beforeEach(async () => {
+      const user = userEvent.setup();
+      render(
+        <CitationDataFilter onCategorySelect={onCategorySelectMock} onDatePresetSelect={onDatePresetSelectMock} />,
+      );
 
-  test("should render date inputs with initial placeholders", async () => {
-    expect(screen.getByLabelText("From")).toHaveTextContent("mm/dd/yy");
-    expect(screen.getByLabelText("To")).toHaveTextContent("mm/dd/yy");
-  });
-});
+      await user.click(screen.getByRole("combobox", { name: "citation-data-categories" }));
+      await user.click(screen.getByRole("option", { name: "Violation Type" }));
 
-describe("Citation-data-filter interactions", () => {
-  const onCategorySelectMock = jest.fn();
-  const onDatePresetSelectMock = jest.fn();
-  beforeEach(async () => {
-    const user = userEvent.setup();
-    render(<CitationDataFilter onCategorySelect={onCategorySelectMock} onDatePresetSelect={onDatePresetSelectMock} />);
+      await user.click(screen.getByRole("combobox", { name: "citation-date-presets" }));
+      await user.click(screen.getByRole("option", { name: "Year to Date" }));
 
-    await user.click(screen.getByRole("combobox", { name: "citation-data-categories" }));
-    await user.click(screen.getByRole("option", { name: "Violation Type" }));
+      await user.click(screen.getByLabelText("From"));
+      await user.click(screen.getByRole("combobox", { name: "Month" }));
+      await user.click(screen.getByRole("option", { name: "January" }));
+      await user.click(screen.getByRole("combobox", { name: "Year" }));
+      await user.click(screen.getByRole("option", { name: "2020" }));
+      await user.click(screen.getByText("25"));
 
-    await user.click(screen.getByRole("combobox", { name: "citation-date-presets" }));
-    await user.click(screen.getByRole("option", { name: "Year to Date" }));
+      await user.click(screen.getByLabelText("To"));
+      await user.click(screen.getByRole("combobox", { name: "Month" }));
+      await user.click(screen.getByRole("option", { name: "February" }));
+      await user.click(screen.getByRole("combobox", { name: "Year" }));
+      await user.click(screen.getByRole("option", { name: "2023" }));
+      await user.click(screen.getByText("27"));
+    });
 
-    await user.click(screen.getByLabelText("From"));
-    await user.click(screen.getByRole("combobox", { name: "Month" }));
-    await user.click(screen.getByRole("option", { name: "January" }));
-    await user.click(screen.getByRole("combobox", { name: "Year" }));
-    await user.click(screen.getByRole("option", { name: "2020" }));
-    await user.click(screen.getByText("25"));
+    it("should not render with default options", () => {
+      expect(screen.queryByText("Total # Citations")).toBe(null);
+      expect(screen.queryByText("Past 1 Year")).toBe(null);
+      expect(screen.queryByText("mm/dd/yy")).toBe(null);
+    });
 
-    await user.click(screen.getByLabelText("To"));
-    await user.click(screen.getByRole("combobox", { name: "Month" }));
-    await user.click(screen.getByRole("option", { name: "February" }));
-    await user.click(screen.getByRole("combobox", { name: "Year" }));
-    await user.click(screen.getByRole("option", { name: "2023" }));
-    await user.click(screen.getByText("27"));
-  });
+    it("should render with selected options", async () => {
+      expect(screen.getByText("Violation Type"));
+      expect(screen.getByText("Year to Date"));
+      expect(screen.getByText("01/25/2020"));
+      expect(screen.getByText("02/27/2023"));
+    });
 
-  test("should not render with default options", () => {
-    expect(screen.queryByText("Total # Citations")).toBe(null);
-    expect(screen.queryByText("Past 1 Year")).toBe(null);
-    expect(screen.queryByText("mm/dd/yy")).toBe(null);
-  });
-
-  test("should render with selected options", async () => {
-    expect(screen.getByText("Violation Type"));
-    expect(screen.getByText("Year to Date"));
-    expect(screen.getByText("01/25/2020"));
-    expect(screen.getByText("02/27/2023"));
-  });
-
-  test("should return selected options", async () => {
-    expect(onCategorySelectMock).toHaveBeenCalledWith("Violation Type");
-    expect(onDatePresetSelectMock).toHaveBeenCalledWith("Year to Date");
+    it("should return selected options", async () => {
+      expect(onCategorySelectMock).toHaveBeenCalledWith("Violation Type");
+      expect(onDatePresetSelectMock).toHaveBeenCalledWith("Year to Date");
+    });
   });
 });

--- a/packages/website/src/features/citation/ui/citation-data-filter.tsx
+++ b/packages/website/src/features/citation/ui/citation-data-filter.tsx
@@ -21,8 +21,8 @@ export default function CitationDataFilter(props: CitationDataFilterProps) {
         <p className="paragraph-2 text-black-400 font-medium">or</p>
 
         <div className="flex flex-auto items-center space-x-1">
-          <DateInput>From</DateInput>
-          <DateInput>To</DateInput>
+          <DateInput id="From">From</DateInput>
+          <DateInput id="To">To</DateInput>
         </div>
       </div>
     </>


### PR DESCRIPTION
### Description

<!--
  Summarize the changes this pull request introduces, including relevant motivation, context, and additional considerations.
  List any dependencies that are required for these changes.
-->

Created citation-data-filter.test.tsx file to test the `CitationDataFilter` component. Within it I test that all fields render with the correct placeholders. I also added interactions with each input field and tested the expected behaviors.

### Related Issues

<!--
  Pull requests are required to be linked to approved issues. Using the proper syntax, list all issues that this pull request addresses.
  Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

  Example: Resolves #123
-->

Resolves #574 

### Testing

<!--
  How have you tested your changes? Provide concise instructions and details to reproduce testing.
  If possible, include a coverage report inline using code blocks (preferred) or as an attachment.

  Example:
    - Write new tests to fully cover new implementation.
    - Adjust tests to cover refactored changes.
-->

- Ran testing suites.
<details><summary>Updated Testing Coverage</summary>
<p>

```
PASS  src/features/citation/ui/citation-data-category-selection.test.tsx
PASS  src/widgets/radius-tool/radius-tool.test.tsx
PASS  ../ui/src/components/modal/modal.test.tsx
PASS  src/features/instructions/how-it-works-button.test.tsx
PASS  src/features/citation/ui/citation-data-filter.test.tsx
PASS  src/features/citation/ui/citation-date-presets-selection.test.tsx
PASS  ../ui/src/components/radio-group/radio-group.test.tsx
PASS  ../ui/src/components/pick-list/pick-list.test.tsx
PASS  ../ui/src/components/stepper/stepper.test.tsx
PASS  ../ui/src/components/input/input.test.tsx
PASS  src/widgets/header/header.test.tsx

Test Suites: 11 passed, 11 total
Tests:       63 passed, 63 total
Snapshots:   0 total
Time:        29.457 s, estimated 31 s
Ran all test suites.
```


File | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-- | -- | -- | -- | -- | --
All files | 19.83 | 21.27 | 21.47 | 19.64 |  
src | 0 | 100 | 100 | 0 |  
main.tsx | 0 | 100 | 100 | 0 | 1-6
vite-env.d.ts | 0 | 0 | 0 | 0 |  
src/app | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1
src/app/ui | 0 | 100 | 0 | 0 |  
app.tsx | 0 | 100 | 0 | 0 | 1-17
index.ts | 0 | 100 | 0 | 0 | 1
src/app/ui/layouts | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1
screen-layout.tsx | 0 | 100 | 0 | 0 | 1-5
src/app/ui/routing | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1
router.tsx | 0 | 100 | 100 | 0 | 1-14
src/entities/branding | 100 | 100 | 100 | 100 |  
index.ts | 100 | 100 | 100 | 100 |  
src/entities/branding/ui | 100 | 100 | 100 | 100 |  
logo.tsx | 100 | 100 | 100 | 100 |  
src/entities/map/lib/controls | 0 | 0 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1-2
map-draw-control.tsx | 0 | 0 | 0 | 0 | 1-75
map-draw-styles.ts | 0 | 100 | 100 | 0 | 1-126
use-map-draw.tsx | 0 | 100 | 0 | 0 | 1-8
src/entities/map/lib/provider | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1
map-provider.tsx | 0 | 100 | 0 | 0 | 1-38
src/entities/navigation | 100 | 100 | 100 | 100 |  
index.ts | 100 | 100 | 100 | 100 |  
src/entities/navigation/lib | 100 | 100 | 100 | 100 |  
paths.ts | 100 | 100 | 100 | 100 |  
src/features/citation | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1-4
src/features/citation/lib | 100 | 100 | 100 | 100 |  
constants.ts | 100 | 100 | 100 | 100 |  
index.ts | 100 | 100 | 100 | 100 |  
src/features/citation/ui | 78.57 | 0 | 71.42 | 76.92 |  
citation-data-category-selection.tsx | 100 | 100 | 100 | 100 |  
citation-data-filter.tsx | 100 | 100 | 100 | 100 |  
citation-data-insights.tsx | 0 | 0 | 0 | 0 | 1-36
citation-date-presets-selection.tsx | 100 | 100 | 100 | 100 |  
src/features/geocoder | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1-5
src/features/geocoder/api | 0 | 0 | 0 | 0 |  
endpoints.ts | 0 | 0 | 0 | 0 | 1-33
index.ts | 0 | 100 | 100 | 0 | 1
requests.ts | 0 | 0 | 0 | 0 | 1-7
src/features/geocoder/lib | 0 | 0 | 0 | 0 |  
constants.ts | 0 | 0 | 0 | 0 | 1-23
utilities.ts | 0 | 0 | 0 | 0 | 1-28
src/features/geocoder/ui | 0 | 0 | 0 | 0 |  
geocoder-result-header.tsx | 0 | 100 | 0 | 0 | 1-4
geocoder-result.tsx | 0 | 100 | 0 | 0 | 1-26
geocoder.tsx | 0 | 0 | 0 | 0 | 1-79
region-types-selection.tsx | 0 | 100 | 0 | 0 | 1-14
search-mode-toggle-button.tsx | 0 | 100 | 0 | 0 | 1-8
src/features/instructions | 77.77 | 100 | 50 | 87.5 |  
how-it-works-button.tsx | 100 | 100 | 100 | 100 |  
index.ts | 0 | 100 | 0 | 0 | 1
src/features/map | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1-5
src/features/map/ui | 0 | 0 | 0 | 0 |  
map.tsx | 0 | 0 | 0 | 0 | 1-60
use-map.tsx | 0 | 0 | 0 | 0 | 1-9
src/features/map/ui/draw | 0 | 0 | 0 | 0 |  
map-draw-action-button.tsx | 0 | 100 | 0 | 0 | 1-6
map-draw-apply-button.tsx | 0 | 0 | 0 | 0 | 1-17
map-draw-button.tsx | 0 | 0 | 0 | 0 | 1-21
map-draw-clear-button.tsx | 0 | 0 | 0 | 0 | 1-24
map-draw-instructions.tsx | 0 | 100 | 0 | 0 | 1-17
src/pages | 0 | 0 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1
page.tsx | 0 | 100 | 0 | 0 | 2-7
parking-insights-page.tsx | 0 | 0 | 0 | 0 | 1-35
src/shared/data | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1-2
src/shared/data/feature-collections | 0 | 100 | 100 | 0 |  
index.ts | 0 | 100 | 100 | 0 | 1-5
src/shared/data/store | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1-4
store.ts | 0 | 100 | 100 | 0 | 1-14
ui-slice.ts | 0 | 100 | 0 | 0 | 3-45
src/shared/lib/constants | 100 | 100 | 100 | 100 |  
date.ts | 100 | 100 | 100 | 100 |  
src/shared/lib/types | 0 | 100 | 100 | 0 |  
index.ts | 0 | 100 | 100 | 0 | 1
src/shared/lib/utilities | 31.03 | 0 | 16.66 | 25 |  
date.ts | 50 | 0 | 33.33 | 35.71 | 5-15,22-25
enum.ts | 0 | 100 | 0 | 0 | 1-5
string.ts | 0 | 0 | 0 | 0 | 1-4
src/shared/lib/utilities/testing | 100 | 50 | 100 | 100 |  
index.ts | 100 | 100 | 100 | 100 |  
test-wrapper.tsx | 100 | 0 | 100 | 100 | 11
testing.tsx | 100 | 66.66 | 100 | 100 | 6
src/shared/ui/date-input | 100 | 100 | 100 | 100 |  
date-input.tsx | 100 | 100 | 100 | 100 |  
index.ts | 100 | 100 | 100 | 100 |  
src/shared/ui/fake-input | 0 | 100 | 0 | 0 |  
fake-input.tsx | 0 | 100 | 0 | 0 | 2-14
index.ts | 0 | 100 | 0 | 0 | 1
src/shared/ui/visualization | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1
visualization-stub.tsx | 0 | 100 | 0 | 0 | 1-2
src/widgets/citation | 0 | 100 | 0 | 0 |  
index.ts | 0 | 100 | 0 | 0 | 1
src/widgets/citation/ui/explorer | 0 | 0 | 0 | 0 |  
citation-explorer-divider.tsx | 0 | 100 | 0 | 0 | 1-2
citation-explorer-section-title.tsx | 0 | 100 | 0 | 0 | 3-4
citation-explorer-section.tsx | 0 | 100 | 0 | 0 | 3-4
citation-explorer-title.tsx | 0 | 0 | 0 | 0 | 2-12
citation-explorer.tsx | 0 | 0 | 0 | 0 | 1-63
src/widgets/citation/ui/search | 0 | 0 | 0 | 0 |  
comparative-search.tsx | 0 | 0 | 0 | 0 | 1-86
draw-search.tsx | 0 | 100 | 0 | 0 | 1-10
single-seach.tsx | 0 | 100 | 0 | 0 | 1-16
src/widgets/citation/ui/visualization | 0 | 0 | 0 | 0 |  
comparative-search-visualization-focused.tsx | 0 | 100 | 0 | 0 | 1-29
comparative-search-visualization.tsx | 0 | 0 | 0 | 0 | 1-39
single-search-visualization.tsx | 0 | 100 | 0 | 0 | 1-32
src/widgets/header | 75 | 100 | 50 | 85.71 |  
header.tsx | 100 | 100 | 100 | 100 |  
index.ts | 0 | 100 | 0 | 0 | 1
src/widgets/radius-tool | 68.57 | 22.22 | 42.85 | 77.41 |  
index.ts | 0 | 100 | 0 | 0 | 1
radius-tool.tsx | 72.72 | 22.22 | 50 | 80 | 27-31,35,54
src/widgets/radius-tool/utils | 54.05 | 50 | 43.75 | 54.05 |  
formatDecimals.ts | 100 | 100 | 100 | 100 |  
unit-convertor.ts | 48.48 | 40 | 40 | 48.48 | 18-23,30-34,40,71-107


<!-- notionvc: a33ca11d-8774-4a43-b59e-b6e12d3ac163 -->

</p>
</details> 

### Checklist

<!--
  Check off items in the list by replacing the space between the square brackets with an `x`.
  You should aim to check off all items in the list.
-->

- [X] I have followed all conventions outlined in our documentation.
- [X] I have fully tested my changes and confirmed that all new and existing tests pass.
- [X] I have written meaningful commit messages for all changes.
- [X] I have linted and formatted my changes to follow the code style of this repository.
- [X] I have updated our documentation, accordingly.
- [X] I have checked currently opened pull requests to ensure that there are no pending pull request for the same changes or issues.
- [X] I have confirmed that this pull request fully meets the acceptance criteria for all related issues listed above.
