### PR TITLE
Create post-an-open-role.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/post-an-open-role.md
+++ b/.github/ISSUE_TEMPLATE/post-an-open-role.md
@@ -1,0 +1,11 @@
+---
+name: Post an open role
+about: Recruit volunteers for specific open roles template
+title: 'LP: Open Role for: [Replace with NAME OF ROLE]'
+labels: 'complexity: Small, feature: recruitment/onboarding, missing: role, missing: milestone'
+assignees: ''
+
+---
+
+![image](https://user-images.githubusercontent.com/37763229/162591479-67a96690-854b-40c2-92e9-735b2bbe09b8.png)
+[INSERT DRAFT FROM THE Recruit volunteers for team open roles issue]


### PR DESCRIPTION
Added a new issue template to post recruitment to open roles

### Description
GitHub has done away with cards on the new project boards.  So we have come up with a new way to post for an open role.  



### Related Issues
This template is part 2 of a 2 part process.  The primary issue is https://github.com/hackforla/lucky-parking/issues/657

>Pull requests are required to be linked to approved issues. Using the proper syntax, list all issues that this pull request addresses.

Except when the org needs something done, and no one from product is coming to the product management meetings on Fridays.  Admin reserves the right to create PRs without issues.


